### PR TITLE
Made the package compatible with Windows

### DIFF
--- a/R/fastBqDownload.R
+++ b/R/fastBqDownload.R
@@ -50,7 +50,11 @@ bqr_download_query <- function(query = NULL,
 
     full_result_path <- paste0(target_folder, "/", result_file_name, ".csv.gz")
     if (file.exists(full_result_path) & !refetch) {
+      if (.Platform$OS.type == 'windows'){
+        return(data.table::fread(paste("gunzip", full_result_path)))
+      } else {
         return(data.table::fread(paste("gunzip -c", full_result_path)))
+      }
     }
 
     setFastSqlDownloadOptions(global_project_name, global_dataset_name, global_bucket_name)
@@ -132,7 +136,11 @@ readFromStorage <- function(object_names, target_folder) {
             saveToDisk = paste0(target_folder, "/", object),
             overwrite = TRUE
         )
-        data.table::fread(paste0("gunzip -c ", target_folder, "/", object))
+        if (.Platform$OS.type == 'windows'){
+          data.table::fread(paste0("gunzip ", target_folder, "/", object))
+        } else {
+          data.table::fread(paste0("gunzip -c ", target_folder, "/", object))
+        }
     })
     data.table::rbindlist(chunk_dt_list)
 }

--- a/R/fastBqDownload.R
+++ b/R/fastBqDownload.R
@@ -51,7 +51,7 @@ bqr_download_query <- function(query = NULL,
     full_result_path <- paste0(target_folder, "/", result_file_name, ".csv.gz")
     if (file.exists(full_result_path) & !refetch) {
       if (.Platform$OS.type == 'windows'){
-        return(data.table::fread(paste("gunzip", full_result_path)))
+        return(data.table::fread(gunzip(full_result_path),encoding='UTF-8'))
       } else {
         return(data.table::fread(paste("gunzip -c", full_result_path)))
       }
@@ -137,7 +137,7 @@ readFromStorage <- function(object_names, target_folder) {
             overwrite = TRUE
         )
         if (.Platform$OS.type == 'windows'){
-          data.table::fread(paste0("gunzip ", target_folder, "/", object))
+          data.table::fread(gunzip(paste0(target_folder, "/", object)),encoding='UTF-8')
         } else {
           data.table::fread(paste0("gunzip -c ", target_folder, "/", object))
         }


### PR DESCRIPTION
The gunzip command is slightly different in Windows. Also, you have to specify UTF-8 to read bigquery's output if you are saving non-standard characters (for example Danish letters), as the Windows default is ISO-8859-1. The gunzip command in Windows requires the R.utils package - i.e. require(R.utils). I'm not sure how you ensure this dependency in an R package, sorry.