### PR TITLE
add location param to bqr_get_job

### DIFF
--- a/R/jobs.R
+++ b/R/jobs.R
@@ -51,7 +51,8 @@ bqr_wait_for_job <- function(job, wait=5){
                                                               format = "%H:%M:%S"), level = 3)
     
     job <- bqr_get_job(projectId = job$jobReference$projectId, 
-                       jobId = job$jobReference$jobId)
+                       jobId = job$jobReference$jobId,
+                       location = job$jobReference$location)
     
     if(getOption("googleAuthR.verbose") <= 2){
       myMessage("job configuration:")
@@ -81,6 +82,7 @@ bqr_wait_for_job <- function(job, wait=5){
 #' 
 #' @param projectId projectId of job
 #' @param jobId jobId to poll, or a job Object
+#' @param location location where job is run. Required for single-region locations when jobId is not a job Object.
 #' 
 #' @return A Jobs resource
 #' 
@@ -134,24 +136,35 @@ bqr_wait_for_job <- function(job, wait=5){
 #' 
 #' @family BigQuery asynch query functions  
 #' @export
-bqr_get_job <- function(jobId = .Last.value, projectId = bqr_get_global_project()){
+bqr_get_job <- function(jobId = .Last.value,
+                        projectId = bqr_get_global_project(),
+                        location = NULL) {
   check_bq_auth()
   
   if(is.job(jobId)){
     jobId <- jobId$jobReference$jobId
+    location <- jobId$jobReference$location
   }
   stopifnot(inherits(projectId, "character"),
             inherits(jobId, "character"))
+
+  if (!is.null(location)) {
+    pars <- list(location = location)
+  } else {
+    pars <- NULL
+  }
   
   ## make job
   job <- 
     googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
                                    "GET",
                                    path_args = list(projects = projectId,
-                                                    jobs = jobId))
+                                                    jobs = jobId),
+                                   pars_args = pars)
   
   req <- job(path_arguments = list(projects = projectId,
-                                   jobs = jobId))
+                                   jobs = jobId),
+             pars_args = pars)
   
   as.job(req$content)
   

--- a/R/uploadData.R
+++ b/R/uploadData.R
@@ -358,7 +358,8 @@ check_req <- function(req, wait) {
                   req$content$jobReference$jobId, level = 3)
         
         out <- bqr_get_job(req$content$jobReference$jobId, 
-                           projectId = req$content$jobReference$projectId)
+                           projectId = req$content$jobReference$projectId,
+                           location = req$content$jobReference$location)
       }
       
     } else {

--- a/man/bqr_get_job.Rd
+++ b/man/bqr_get_job.Rd
@@ -4,12 +4,18 @@
 \alias{bqr_get_job}
 \title{Poll a jobId}
 \usage{
-bqr_get_job(jobId = .Last.value, projectId = bqr_get_global_project())
+bqr_get_job(
+  jobId = .Last.value,
+  projectId = bqr_get_global_project(),
+  location = NULL
+)
 }
 \arguments{
 \item{jobId}{jobId to poll, or a job Object}
 
 \item{projectId}{projectId of job}
+
+\item{location}{location where job is run. Required for single-region locations when jobId is not a job Object.}
 }
 \value{
 A Jobs resource


### PR DESCRIPTION
Hi @MarkEdmondson1234,

Here is my implementation of the bqr_get_job location param as discussed in issue #71.
The location is either parsed from the job object or takes the user input. NULL value is accepted for backward compatibility, which still works for EU and US location.
Within the package job location is passed to the function whenever it is called.

I didn't add any tests as it would require datasets in a different location, but it worked in my 'testing environment'.

Cheers,
Eszter