### PR TITLE
Align Google APIs URLs with Discovery docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # bigQuery 0.5.0.9000
 
 * Add missing numeric type for BigQuery schema parsing (#65)
+* Align Google APIs URLs to Google Cloud Discovery docs. This enables support for Private and Restricted Google APIs configurations. (@husseyd, #81)
+  - Substitute `https://bigquery.googleapis.com` for `https://www.googleapis.com`
 
 # bigQueryR 0.5.0
 

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -32,7 +32,7 @@
 bqr_list_datasets <- function(projectId = bqr_get_global_project()){
   
   check_bq_auth()
-  l <- gar_api_generator("https://www.googleapis.com/bigquery/v2",
+  l <- gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                          "GET",
                          path_args = list(projects = projectId,
                                           datasets = ""),

--- a/R/downloadData.R
+++ b/R/downloadData.R
@@ -99,7 +99,7 @@ bqr_extract_data <- function(projectId = bqr_get_global_project(),
   
   ## make job
   job <- 
-    googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+    googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                    "POST",
                                    path_args = list(projects = projectId,
                                                     jobs = "")

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -12,7 +12,7 @@ is.job <- function(x){
 # metadata only jobs
 call_job <- function(projectId, config){
   l <- 
-    googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+    googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                    "POST",
                                    path_args = list(projects = projectId,
                                                     jobs = ""),
@@ -145,7 +145,7 @@ bqr_get_job <- function(jobId = .Last.value, projectId = bqr_get_global_project(
   
   ## make job
   job <- 
-    googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+    googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                    "GET",
                                    path_args = list(projects = projectId,
                                                     jobs = jobId))
@@ -194,7 +194,7 @@ bqr_list_jobs <- function(projectId = bqr_get_global_project(),
   options("googleAuthR.jsonlite.simplifyVector" = FALSE )
   ## make job
   job <- 
-    googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+    googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                    "GET",
                                    path_args = list(projects = projectId,
                                                     jobs = ""),

--- a/R/listBigQuery.R
+++ b/R/listBigQuery.R
@@ -25,7 +25,7 @@
 #' @export
 bqr_list_projects <- function(){
   check_bq_auth()
-  l <- googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2/projects",
+  l <- googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2/projects",
                                       "GET",
                                       data_parse_function = function(x) {
                                         d <- x$projects

--- a/R/query.R
+++ b/R/query.R
@@ -64,7 +64,7 @@ bqr_query <- function(projectId = bqr_get_global_project(),
   body <- rmNullObs(body)
   
   # solve 404?
-  the_url <- sprintf("https://www.googleapis.com/bigquery/v2/projects/%s/queries", projectId)
+  the_url <- sprintf("https://bigquery.googleapis.com/bigquery/v2/projects/%s/queries", projectId)
   
   if(dryRun){
     q <- googleAuthR::gar_api_generator(the_url,
@@ -95,7 +95,7 @@ bqr_query <- function(projectId = bqr_get_global_project(),
   if(!is.null(pageToken)){
     message("Paging through query results")
     jobId <- attr(data, "jobReference")$jobId
-    pr <- googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+    pr <- googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                          "GET",
                                          path_args = list(projects = projectId,
                                                           queries = jobId),
@@ -213,7 +213,7 @@ bqr_query_asynch <- function(projectId = bqr_get_global_project(),
   check_bq_auth()
   ## make job
   job <- 
-    googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+    googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                    "POST",
                                    path_args = list(projects = projectId,
                                                     jobs = "")

--- a/R/tables.R
+++ b/R/tables.R
@@ -103,7 +103,7 @@ bqr_list_tables <- function(projectId = bqr_get_global_project(),
   
   
   check_bq_auth()
-  l <- gar_api_generator("https://www.googleapis.com/bigquery/v2",
+  l <- gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                          "GET",
                          path_args = list(projects = projectId,
                                           datasets = datasetId,
@@ -163,7 +163,7 @@ bqr_table_meta <- function(projectId = bqr_get_global_project(),
   }
   
   
-  l <- googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+  l <- googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                       "GET",
                                       path_args = list(projects = projectId,
                                                        datasets = datasetId,
@@ -196,7 +196,7 @@ bqr_table_data <- function(projectId = bqr_get_global_project(),
                            tableId,
                            maxResults = 1000){
   check_bq_auth()
-  l <- googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+  l <- googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                       "GET",
                                       path_args = list(projects = projectId,
                                                        datasets = datasetId,
@@ -242,7 +242,7 @@ bqr_create_table <- function(projectId = bqr_get_global_project(),
                              timePartitioning = FALSE,
                              expirationMs = 0L){
   check_bq_auth()
-  l <- googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+  l <- googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                       "POST",
                                       path_args = list(projects = projectId,
                                                        datasets = datasetId,
@@ -320,7 +320,7 @@ bqr_patch_table <- function(Table){
   
   myMessage("Patching ", tableId, level = 3)
   
-  the_url <- sprintf("https://www.googleapis.com/bigquery/v2/projects/%s/datasets/%s/tables/%s",
+  the_url <- sprintf("https://bigquery.googleapis.com/bigquery/v2/projects/%s/datasets/%s/tables/%s",
                      projectId, datasetId, tableId)
   
   call_api <- gar_api_generator(the_url, "PATCH", data_parse_function = function(x) x)
@@ -349,7 +349,7 @@ bqr_delete_table <- function(projectId = bqr_get_global_project(),
                              datasetId = bqr_get_global_dataset(), 
                              tableId){
   check_bq_auth()
-  l <- googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+  l <- googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                       "DELETE",
                                       path_args = list(projects = projectId,
                                                        datasets = datasetId,

--- a/R/uploadData.R
+++ b/R/uploadData.R
@@ -300,7 +300,7 @@ bqr_do_upload.data.frame <- function(upload_data,
 
 do_obj_req <- function(mp_body, projectId, datasetId, tableId) {
   l <- 
-    googleAuthR::gar_api_generator("https://www.googleapis.com/upload/bigquery/v2",
+    googleAuthR::gar_api_generator("https://bigquery.googleapis.com/upload/bigquery/v2",
                                    "POST",
                                    path_args = list(projects = projectId,
                                                     jobs = ""),
@@ -441,7 +441,7 @@ bqr_do_upload.character <- function(upload_data,
   config <- rmNullObs(config)
   
   l <- 
-    googleAuthR::gar_api_generator("https://www.googleapis.com/bigquery/v2",
+    googleAuthR::gar_api_generator("https://bigquery.googleapis.com/bigquery/v2",
                                    "POST",
                                    path_args = list(projects = projectId,
                                                     jobs = ""),


### PR DESCRIPTION
Align Google APIs URLs with Discovery docs per #81 

Align Google APIs URLs to Google Cloud Discovery docs. This enables support for Private and Restricted Google APIs configurations.
  - Wherever old BigQuery Google APIs url is present, replace with new URL per Google discovery docs.
    - Substitute `https://bigquery.googleapis.com` for `https://www.googleapis.com`
  - No updates to OAuth scope URLs 
    - (E.G. `https://www.googleapis.com/auth...`). These do not require change.


Reference:

- [BigQuery API ref](https://cloud.google.com/bigquery/docs/reference/rest)
- [VPC Service Controls Overview](https://cloud.google.com/vpc-service-controls/docs/overview)
- [Private and Restricted Google APIs networking and DNS](https://cloud.google.com/vpc/docs/configure-private-google-access-hybrid#ipv6-support)